### PR TITLE
Add a Path Workflow Call Argument to the SwiftLint Workflow

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -21,9 +21,6 @@ jobs:
   swiftlint:
     name: SwiftLint
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.path }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -33,3 +30,5 @@ jobs:
         with:
           swiftlint-version: '0.50.0'
           swiftlint-args: --strict
+        env:
+          WORKING_DIRECTORY: ${{ inputs.path }}

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -21,6 +21,9 @@ jobs:
   swiftlint:
     name: SwiftLint
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.path }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -30,5 +33,3 @@ jobs:
         with:
           swiftlint-version: '0.50.0'
           swiftlint-args: --strict
-        env:
-          WORKING_DIRECTORY: ${{ inputs.path }}

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -10,6 +10,12 @@ name: SwiftLint
 
 on:
   workflow_call:
+    inputs:
+      path:
+        description: 'The path where the project is located. Defaults to $GITHUB_WORKSPACE'
+        required: false
+        type: string
+        default: '.'
 
 jobs:
   swiftlint:
@@ -24,3 +30,5 @@ jobs:
         with:
           swiftlint-version: '0.50.0'
           swiftlint-args: --strict
+        env:
+          WORKING_DIRECTORY: ${{ inputs.path }}


### PR DESCRIPTION
# Add a Path Workflow Call Argument to the SwiftLint Workflow

## :recycle: Current situation & Problem
- The current SwiftLint workflow does not have a mechanism to configure the path where the action should be run.

## :bulb: Proposed solution
- This PR adds the `path` property to run the SwiftLint action at a specific path.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
