### PR TITLE
Run Artifact Upload Only if an Artifact Name Has Been Provided

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -167,7 +167,7 @@ jobs:
         APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
         APPLE_ID: ${{ secrets.APPLE_ID }}
     - name: Upload artifact
-      if: always()
+      if: ${{ (success() || failure()) && inputs.artifactname != '' }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.artifactname }}


### PR DESCRIPTION
# Run Artifact Upload Only if an Artifact Name Has Been Provided

## :recycle: Current situation & Problem
- Artifacts are uploaded even if no artifact name has been provided

## :bulb: Proposed solution
- Adds additional checks


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
