### PR TITLE
Replace SwiftLint action

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: SwiftLint
-        uses: sinoru/actions-swiftlint@v6
+        uses: Supereg/actions-swiftlint@v4
         with:
-          swiftlint-version: '0.50.0'
-          swiftlint-args: --strict
+          args: --strict


### PR DESCRIPTION
# Replace SwiftLint action

## :recycle: Current situation & Problem
Currently, we rely on a SwiftLint action that manually builds swiftlint from source when running.

## :bulb: Proposed solution
This PR replaces the SwiftLint action with our [own](https://github.com/marketplace/actions/swiftlint-tool) that combines using the official [swiftlint docker image](https://github.com/realm/SwiftLint/pkgs/container/swiftlint) with having [inline warnings](https://github.com/marketplace/actions/swiftlint-tool#example)

## :gear: Release Notes 
* Updated SwiftLint action

## :heavy_plus_sign: Additional Information

### Related PRs
--

### Testing
Testing was done in the CI of the project.

### Reviewer Nudging
Refer to [this PR](https://github.com/Supereg/action-swiftlint/pull/2)

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
