### PR TITLE
Hotfix for mispelled SwiftLint action

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: SwiftLint
-        uses: Supereg/action-swiftlint@v4
+        uses: supereg/action-swiftlint@v4
         with:
           args: --strict

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: SwiftLint
-        uses: Supereg/actions-swiftlint@v4
+        uses: Supereg/action-swiftlint@v4
         with:
           args: --strict


### PR DESCRIPTION
# Hotfix for mispelled SwiftLint action

## :recycle: Current situation & Problem
The action name is spelled incorrectly.

## :bulb: Proposed solution
Update the action name 🙃 

## :gear: Release Notes 
* Fixed misspelled SwiftLint action name

## :heavy_plus_sign: Additional Information
I'm sorry for the disruptions.

### Related PRs
--

### Testing
--

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
