### PR TITLE
Add GitHub Action to Automatically Tag Major and Minor Tags on a New Release

### DIFF
--- a/.github/workflows/action-release-tag.yml
+++ b/.github/workflows/action-release-tag.yml
@@ -1,0 +1,45 @@
+#
+# This source file is part of the Stanford Spezi open-source project
+#
+# SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Action Tag Release
+
+on:
+  workflow_call:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  tagrelease:
+    name: Action Tag Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: latest-version
+      - name: Retrieve version
+        run: |
+          VERSION=${{ steps.latest-version.outputs.tag }}
+          MAJOR=${VERSION%%.*}
+          MINOR=${VERSION%.*}
+          
+          echo "major=$MAJOR" >> $GITHUB_OUTPUT
+          echo "minor=$MINOR" >> $GITHUB_OUTPUT
+        id: version
+      - uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: ${{ steps.version.outputs.major }}
+          message: ${{ steps.version.outputs.major }}
+      - uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: ${{ steps.version.outputs.minor }}
+          message: '${{ steps.version.outputs.minor }}

--- a/.github/workflows/action-release-tag.yml
+++ b/.github/workflows/action-release-tag.yml
@@ -31,7 +31,7 @@ jobs:
           VERSION=${{ steps.latest-version.outputs.tag }}
           MAJOR=${VERSION%%.*}
           MINOR=${VERSION%.*}
-          
+
           echo "major=$MAJOR" >> $GITHUB_OUTPUT
           echo "minor=$MINOR" >> $GITHUB_OUTPUT
         id: version
@@ -42,4 +42,4 @@ jobs:
       - uses: actions-ecosystem/action-push-tag@v1
         with:
           tag: ${{ steps.version.outputs.minor }}
-          message: '${{ steps.version.outputs.minor }}
+          message: ${{ steps.version.outputs.minor }}

--- a/.github/workflows/action-release-tag.yml
+++ b/.github/workflows/action-release-tag.yml
@@ -1,7 +1,7 @@
 #
 # This source file is part of the Stanford Spezi open-source project
 #
-# SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+# SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
 # SPDX-License-Identifier: MIT
 #

--- a/.github/workflows/action-release-tag.yml
+++ b/.github/workflows/action-release-tag.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions-ecosystem/action-get-latest-tag@v1
-        id: latest-version
+        id: latest-tag
       - name: Retrieve version
         run: |
-          VERSION=${{ steps.latest-version.outputs.tag }}
+          VERSION=${{ steps.latest-tag.outputs.tag }}
           MAJOR=${VERSION%%.*}
           MINOR=${VERSION%.*}
 


### PR DESCRIPTION
# Add GitHub Action to Automatically Tag Major and Minor Tags on a New Release

## :recycle: Current situation & Problem
- Tagging a new release in a repo with GitHub Actions requires one to manually tag a new major and minor release.

## :bulb: Proposed solution
- Creates a reusable GitHub Action to do this automatically

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
