### PR TITLE
Improve Tag Creation for GitHub Actions

### DIFF
--- a/.github/workflows/action-release-tag.yml
+++ b/.github/workflows/action-release-tag.yml
@@ -1,0 +1,45 @@
+#
+# This source file is part of the Stanford Spezi open-source project
+#
+# SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Action Tag Release
+
+on:
+  workflow_call:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  tagrelease:
+    name: Action Tag Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: latest-version
+      - name: Retrieve version
+        run: |
+          VERSION=${{ steps.latest-version.outputs.tag }}
+          MAJOR=${VERSION%%.*}
+          MINOR=${VERSION%.*}
+          
+          echo "major=$MAJOR" >> $GITHUB_OUTPUT
+          echo "minor=$MINOR" >> $GITHUB_OUTPUT
+        id: version
+      - uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: ${{ steps.version.outputs.major }}
+          message: ${{ steps.version.outputs.major }}
+      - uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: ${{ steps.version.outputs.minor }}
+          message: '${{ steps.version.outputs.minor }}

--- a/.github/workflows/action-release-tag.yml
+++ b/.github/workflows/action-release-tag.yml
@@ -31,7 +31,7 @@ jobs:
           VERSION=${{ steps.latest-version.outputs.tag }}
           MAJOR=${VERSION%%.*}
           MINOR=${VERSION%.*}
-          
+
           echo "major=$MAJOR" >> $GITHUB_OUTPUT
           echo "minor=$MINOR" >> $GITHUB_OUTPUT
         id: version
@@ -42,4 +42,4 @@ jobs:
       - uses: actions-ecosystem/action-push-tag@v1
         with:
           tag: ${{ steps.version.outputs.minor }}
-          message: '${{ steps.version.outputs.minor }}
+          message: ${{ steps.version.outputs.minor }}

--- a/.github/workflows/action-release-tag.yml
+++ b/.github/workflows/action-release-tag.yml
@@ -32,14 +32,9 @@ jobs:
           MAJOR=${VERSION%%.*}
           MINOR=${VERSION%.*}
 
-          echo "major=$MAJOR" >> $GITHUB_OUTPUT
-          echo "minor=$MINOR" >> $GITHUB_OUTPUT
-        id: version
-      - uses: actions-ecosystem/action-push-tag@v1
-        with:
-          tag: ${{ steps.version.outputs.major }}
-          message: ${{ steps.version.outputs.major }}
-      - uses: actions-ecosystem/action-push-tag@v1
-        with:
-          tag: ${{ steps.version.outputs.minor }}
-          message: ${{ steps.version.outputs.minor }}
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+          git tag -a "${MAJOR}" -m "${MAJOR}"
+          git tag -a "${MINOR}" -m "${MINOR}"
+          git push -f --tags

--- a/.github/workflows/action-release-tag.yml
+++ b/.github/workflows/action-release-tag.yml
@@ -9,9 +9,19 @@
 name: Action Tag Release
 
 on:
-  workflow_call:
-  release:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      user:
+        description: 'Optional GitHub username that is associated with the GitHub Personal Access Token (PAT)'
+        type: string
+        required: false
+        default: ''
+    secrets:
+      access-token:
+        description: 'GitHub Personal Access Token (PAT) if the default branch is protected and needs a specific access token to push tags to the branch'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -24,6 +34,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ github.event.secrets.access-token || github.token }}
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: latest-version
       - name: Retrieve version
@@ -31,10 +42,10 @@ jobs:
           VERSION=${{ steps.latest-version.outputs.tag }}
           MAJOR=${VERSION%%.*}
           MINOR=${VERSION%.*}
-
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-
+          
+          git config user.name "${{ github.event.inputs.user || github.actor }}"
+          git config user.email "${{ github.event.inputs.user || github.actor }}@users.noreply.github.com"
+          
           git tag -a "${MAJOR}" -m "${MAJOR}"
           git tag -a "${MINOR}" -m "${MINOR}"
           git push -f --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+#
+# This source file is part of the Stanford Spezi open-source project
+#
+# SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Release
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  releasetag:
+    name: Tag Release
+    uses: ./.github/workflows/action-release-tag.yml
+    secrets:
+      access-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    with:
+      user: PaulsAutomationBot

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,19 @@
 # SPDX-License-Identifier: MIT
 #
 
-name: REUSE Compliance Check
+name: Test
 
 on:
-  workflow_call:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
-  reuse:
+  reuse_action:
     name: REUSE Compliance Check
-    runs-on: ubuntu-latest
-    steps: 
-    - uses: actions/checkout@v3
-    - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v1
+    uses: ./.github/workflows/reuse.yml
+  swiftlint:
+    name: SwiftLint
+    uses: ./.github/workflows/swiftlint.yml


### PR DESCRIPTION
# Improve Tag Creation for GitHub Actions

## :recycle: Current situation & Problem
- Fixes an issue where a action did not have the permissions to push to the default repo

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
