### PR TITLE
Disable Password Autofill in the Testing Script

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -32,10 +32,15 @@ on:
         type: string
         default: ''
       destination:
-        description: 'The destination parameter that should be passed to xcodebuild. Defaults to the iOS simulator using an iPhone 14 Pro'
+        description: 'The destination parameter that should be passed to xcodebuild. Defaults to the iOS simulator using an iPhone 15 Pro'
         required: false
         type: string
         default: 'platform=iOS Simulator,name=iPhone 15 Pro'
+      setupSimulators:
+        description: 'Flag indicating if all iOS simulators matching the `destination` input shoud be setup (e.g. password autofill functionality should be disabled).'
+        required: false
+        type: boolean
+        default: true
       resultBundle:
         description: 'The name of the Xcode result bundle that is passed to xcodebuild. If not defined, the name of the scheme + .xcresult is used.'
         required: false
@@ -224,6 +229,64 @@ jobs:
       with:
         languages: swift
         db-location: '${{ inputs.path }}/.codeql'
+    - name: Disable Password Autofill in the iOS Simulator
+      if: ${{ inputs.setupSimulators && inputs.destination != '' }}
+      run: |
+        # Function to parse the device name from input string
+        parse_device_name() {
+            local input_str=$1
+            local IFS=',' # Set Internal Field Separator to comma for splitting
+
+            for kv in $input_str; do
+                key="${kv%%=*}"     # Extract key (everything before '=')
+                value="${kv#*=}"    # Extract value (everything after '=')
+                
+                if [ "$key" = "name" ]; then
+                    echo "$value"
+                    return
+                fi
+            done
+        }
+
+        # Function to check if a simulator is running
+        is_simulator_running() {
+            local simulator_id=$1
+            xcrun simctl list devices | grep -E "$simulator_id \(Booted\)" &> /dev/null
+            return $?
+        }
+
+        # Extract device name from the input (assuming it's passed as the first argument)
+        input=${1:-"platform=iOS Simulator,name=iPhone 15 Pro"}
+        DEVICE_NAME=$(parse_device_name "$input")
+
+        echo "Device name: $DEVICE_NAME"
+
+        # Retrieve the iOS simulator IDs for the specified device
+        SIMULATOR_IDS=$(xctrace list devices | grep "$DEVICE_NAME" | awk '{print $NF}' | tr -d '()')
+
+        # Check if SIMULATOR_IDS is empty
+        if [ -z "$SIMULATOR_IDS" ]; then
+            echo "No simulators found for the specified device."
+            exit 1
+        fi
+
+        # Loop through each Simulator ID
+        for SIMULATOR_ID in $SIMULATOR_IDS; do
+            echo "Processing Simulator ID: $SIMULATOR_ID"
+
+            # Disable AutoFillPasswords
+            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Containers/Shared/SystemGroup/systemgroup.com.apple.configurationprofiles/Library/ConfigurationProfiles/UserSettings.plist
+            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/UserConfigurationProfiles/EffectiveUserSettings.plist
+            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/UserConfigurationProfiles/PublicInfo/PublicEffectiveUserSettings.plist
+
+            # Check if the simulator is running and shut it down if it is
+            if is_simulator_running "$SIMULATOR_ID"; then
+                echo "Shutting down simulator $SIMULATOR_ID."
+                xcrun simctl shutdown "$SIMULATOR_ID"
+            else
+                echo "Simulator $SIMULATOR_ID is already shutdown."
+            fi
+        done
     - name: Run custom command
       if: ${{ inputs.customcommand != '' }}
       run: ${{ inputs.customcommand }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -32,15 +32,15 @@ on:
         type: string
         default: ''
       destination:
-        description: 'The destination parameter that should be passed to xcodebuild. Defaults to the iOS simulator using an iPhone 15 Pro'
+        description: 'The destination parameter that should be passed to xcodebuild. Defaults to the iOS simulator using an iPhone 15 Pro Simulator'
         required: false
         type: string
-        default: 'platform=iOS Simulator,name=iPhone 15 Pro'
+        default: 'platform=iOS Simulator,name=iPhone 15 Pro Simulator'
       setupSimulators:
         description: 'Flag indicating if all iOS simulators matching the `destination` input shoud be setup (e.g. password autofill functionality should be disabled).'
         required: false
         type: boolean
-        default: true
+        default: false
       resultBundle:
         description: 'The name of the Xcode result bundle that is passed to xcodebuild. If not defined, the name of the scheme + .xcresult is used.'
         required: false
@@ -236,7 +236,7 @@ jobs:
         parse_device_name() {
             local input_str=$1
             local IFS=',' # Set Internal Field Separator to comma for splitting
-
+            
             for kv in $input_str; do
                 key="${kv%%=*}"     # Extract key (everything before '=')
                 value="${kv#*=}"    # Extract value (everything after '=')
@@ -248,19 +248,11 @@ jobs:
             done
         }
 
-        # Function to check if a simulator is running
-        is_simulator_running() {
-            local simulator_id=$1
-            xcrun simctl list devices | grep -E "$simulator_id \(Booted\)" &> /dev/null
-            return $?
-        }
-
-        # Extract device name from the input (assuming it's passed as the first argument)
-        input=${1:-"platform=iOS Simulator,name=iPhone 15 Pro"}
-        DEVICE_NAME=$(parse_device_name "$input")
+        # Extract device name from the input
+        DEVICE_NAME=$(parse_device_name "${{ inputs.destination }}")
 
         echo "Device name: $DEVICE_NAME"
-
+        
         # Retrieve the iOS simulator IDs for the specified device
         SIMULATOR_IDS=$(xctrace list devices | grep "$DEVICE_NAME" | awk '{print $NF}' | tr -d '()')
 
@@ -274,17 +266,37 @@ jobs:
         for SIMULATOR_ID in $SIMULATOR_IDS; do
             echo "Processing Simulator ID: $SIMULATOR_ID"
 
-            # Disable AutoFillPasswords
-            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Containers/Shared/SystemGroup/systemgroup.com.apple.configurationprofiles/Library/ConfigurationProfiles/UserSettings.plist
-            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/UserConfigurationProfiles/EffectiveUserSettings.plist
-            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO ~/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/UserConfigurationProfiles/PublicInfo/PublicEffectiveUserSettings.plist
+            xcrun simctl boot "$SIMULATOR_ID"
 
-            # Check if the simulator is running and shut it down if it is
-            if is_simulator_running "$SIMULATOR_ID"; then
-                echo "Shutting down simulator $SIMULATOR_ID."
-                xcrun simctl shutdown "$SIMULATOR_ID"
+            PLIST1="$HOME/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Containers/Shared/SystemGroup/systemgroup.com.apple.configurationprofiles/Library/ConfigurationProfiles/UserSettings.plist"
+            PLIST2="$HOME/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/UserConfigurationProfiles/EffectiveUserSettings.plist"
+            PLIST3="$HOME/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/UserConfigurationProfiles/PublicInfo/PublicEffectiveUserSettings.plist"
+
+            # Loop for a maximum of 30 seconds
+            for (( i=0; i<30; i++ )); do
+                if [ -f "$PLIST1" ] && [ -f "$PLIST2" ] && [ -f "$PLIST3" ]; then
+                    echo "All files found."
+                    break
+                fi
+                sleep 1
+            done
+
+            # Check if the loop exited because all files were found or because of timeout
+            if [ ! -f "$PLIST1" ] || [ ! -f "$PLIST2" ] || [ ! -f "$PLIST3" ]; then
+                echo "Error: Not all files were found within the 30-second timeout."
+                exit 1
+            fi
+
+            # Disable AutoFillPasswords
+            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST1
+            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST2
+            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST3
+
+            # Restart (shutdown if needed and boot) the iOS simulator for the changes to take effect
+            if xcrun simctl shutdown "$SIMULATOR_ID"; then
+                echo "Simulator $SIMULATOR_ID shutdown successfully."
             else
-                echo "Simulator $SIMULATOR_ID is already shutdown."
+                echo "Unable to shutdown simulator $SIMULATOR_ID as it is already shutdown."
             fi
         done
     - name: Run custom command

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -32,10 +32,10 @@ on:
         type: string
         default: ''
       destination:
-        description: 'The destination parameter that should be passed to xcodebuild. Defaults to the iOS simulator using an iPhone 15 Pro Simulator'
+        description: 'The destination parameter that should be passed to xcodebuild. Defaults to the iOS simulator using an iPhone 15 Pro'
         required: false
         type: string
-        default: 'platform=iOS Simulator,name=iPhone 15 Pro Simulator'
+        default: 'platform=iOS Simulator,name=iPhone 15 Pro'
       setupSimulators:
         description: 'Flag indicating if all iOS simulators matching the `destination` input shoud be setup (e.g. password autofill functionality should be disabled).'
         required: false
@@ -254,7 +254,8 @@ jobs:
         echo "Device name: $DEVICE_NAME"
         
         # Retrieve the iOS simulator IDs for the specified device
-        SIMULATOR_IDS=$(xctrace list devices | grep "$DEVICE_NAME" | awk '{print $NF}' | tr -d '()')
+        REGEX_PATTERN="$DEVICE_NAME( Simulator)? \(.*\)"
+        SIMULATOR_IDS=$(xctrace list devices | grep -E "$REGEX_PATTERN" | awk '{print $NF}' | tr -d '()')
 
         # Check if SIMULATOR_IDS is empty
         if [ -z "$SIMULATOR_IDS" ]; then

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -297,6 +297,7 @@ jobs:
             plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST1
             plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST2
             plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST3
+            /usr/libexec/PlistBuddy -c "Add :KeyboardContinuousPathEnabled bool false" /Users/githubaction/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/Preferences/com.apple.keyboard.ContinuousPath.plist
 
             sleep 1
 

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -291,10 +291,14 @@ jobs:
                 exit 1
             fi
 
+            sleep 5
+
             # Disable AutoFillPasswords
             plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST1
             plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST2
             plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST3
+
+            sleep 1
 
             # Restart (shutdown if needed and boot) the iOS simulator for the changes to take effect
             if xcrun simctl shutdown "$SIMULATOR_ID"; then

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -267,11 +267,14 @@ jobs:
         for SIMULATOR_ID in $SIMULATOR_IDS; do
             echo "Processing Simulator ID: $SIMULATOR_ID"
 
-            xcrun simctl boot "$SIMULATOR_ID"
-
             PLIST1="$HOME/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Containers/Shared/SystemGroup/systemgroup.com.apple.configurationprofiles/Library/ConfigurationProfiles/UserSettings.plist"
             PLIST2="$HOME/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/UserConfigurationProfiles/EffectiveUserSettings.plist"
             PLIST3="$HOME/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/UserConfigurationProfiles/PublicInfo/PublicEffectiveUserSettings.plist"
+
+            if [ ! -f "$PLIST1" ] || [ ! -f "$PLIST2" ] || [ ! -f "$PLIST3" ]; then
+                echo "Simulator $SIMULATOR_ID booting ..."
+                xcrun simctl boot "$SIMULATOR_ID"
+            fi
 
             # Loop for a maximum of 30 seconds
             for (( i=0; i<30; i++ )); do


### PR DESCRIPTION
# Disable Password Autofill in the Testing Script

## :recycle: Current situation & Problem
- https://github.com/StanfordBDHG/XCTestExtensions/pull/18


## :gear: Release Notes 
- Tries to disable password autofill in the iOS simulator using a setup script


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
