### PR TITLE
Add build configuration parameter to enable `Debug` or `Release` builds

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,9 +346,9 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\"\$(inherited) -enable-testing\""
+              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=$(inherited) -enable-testing"
           else
-              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\"\$(inherited)\""
+              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=$(inherited)"
           fi
 
           set -o pipefail \

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,9 +346,9 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\$(inherited) -enable-testing"
+              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\"\$(inherited) -enable-testing\""
           else
-              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\$(inherited)"
+              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\"\$(inherited)\""
           fi
 
           set -o pipefail \

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,7 +346,7 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-              ENABLE_TESTING_FLAG='OTHER_SWIFT_FLAGS="-enable-testing $(inherited)"'
+              ENABLE_TESTING_FLAG='OTHER_SWIFT_FLAGS="\$(inherited) -enable-testing"'
               echo "ENABLE_TESTING_FLAG: $ENABLE_TESTING_FLAG"
           else
               ENABLE_TESTING_FLAG=""

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -347,6 +347,7 @@ jobs:
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
               ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\"\$(inherited) -enable-testing\""
+              echo "ENABLE_TESTING_FLAG: $ENABLE_TESTING_FLAG"
           else
               ENABLE_TESTING_FLAG=""
           fi

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,9 +346,9 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=-enable-testing"
+              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\$(inherited) -enable-testing"
           else
-              ENABLE_TESTING_FLAG=""
+              ENABLE_TESTING_FLAG="\$(inherited)"
           fi
 
           set -o pipefail \

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: string
         default: ''
+      buildConfig:
+        description: 'The build configuration parameter that should be passed to xcodebuild. Either use `Debug` or `Release` to build in the respective modes. If not defined, the `Debug` configuration is used.'
+        required: false
+        type: string
+        default: 'Debug'
       destination:
         description: 'The destination parameter that should be passed to xcodebuild. Defaults to the iOS simulator using an iPhone 15 Pro'
         required: false
@@ -343,6 +348,7 @@ jobs:
           set -o pipefail \
           && xcodebuild $XCODECOMMAND \
             -scheme "${{ inputs.scheme }}" \
+            -configuration "${{ inputs.buildConfig }}" \
             -destination "${{ inputs.destination }}" \
             $CODECOVERAGEFLAG \
             -derivedDataPath ".derivedData" \

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -374,7 +374,7 @@ jobs:
       if: ${{ !env.selfhosted && inputs.codeql }}
       uses: github/codeql-action/analyze@v2
     - name: Upload artifact
-      if: ${{ (success() || failure()) && inputs.artifactname != '' }}
+      if: ${{ (success() || failure()) && inputs.artifactname != '' && inputs.buildConfig != 'Release' }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.artifactname }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,8 +346,7 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\"\$(inherited) -enable-testing\""
-              echo "ENABLE_TESTING_FLAG: $ENABLE_TESTING_FLAG"
+              ENABLE_TESTING_FLAG="-enable-testing"
           else
               ENABLE_TESTING_FLAG=""
           fi
@@ -361,7 +360,7 @@ jobs:
             -derivedDataPath ".derivedData" \
             -resultBundlePath "$RESULTBUNDLE" \
             CODE_SIGNING_REQUIRED=NO \
-            OTHER_SWIFT_FLAGS="\$(inherited) -enable-testing" \
+            OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG" \
           | xcpretty
     - name: Fastlane
       if: ${{ inputs.fastlanelane != '' }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,7 +346,7 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-              ENABLE_TESTING_FLAG='OTHER_SWIFT_FLAGS="-enable-testing \$(inherited)"'
+              ENABLE_TESTING_FLAG='OTHER_SWIFT_FLAGS="-enable-testing $(inherited)"'
               echo "ENABLE_TESTING_FLAG: $ENABLE_TESTING_FLAG"
           else
               ENABLE_TESTING_FLAG=""

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,7 +346,7 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\"\$(inherited) -enable-testing\""
+              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\"-enable-testing \$(inherited)\""
               echo "ENABLE_TESTING_FLAG: $ENABLE_TESTING_FLAG"
           else
               ENABLE_TESTING_FLAG=""

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -348,7 +348,7 @@ jobs:
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
               ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\$(inherited) -enable-testing"
           else
-              ENABLE_TESTING_FLAG="\$(inherited)"
+              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\$(inherited)"
           fi
 
           set -o pipefail \

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,11 +346,9 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\$(inherited) -enable-testing"
-              echo "Build config is Release. Setting ENABLE_TESTING_FLAG to '$ENABLE_TESTING_FLAG'"
+              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=-enable-testing"
           else
               ENABLE_TESTING_FLAG=""
-              echo "Build config is not Release. ENABLE_TESTING_FLAG is not set."
           fi
 
           set -o pipefail \
@@ -362,7 +360,7 @@ jobs:
             -derivedDataPath ".derivedData" \
             -resultBundlePath "$RESULTBUNDLE" \
             CODE_SIGNING_REQUIRED=NO \
-            $ENABLE_TESTING_FLAG
+            $ENABLE_TESTING_FLAG \
           | xcpretty
     - name: Fastlane
       if: ${{ inputs.fastlanelane != '' }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,7 +346,7 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\"-enable-testing \$(inherited)\""
+              ENABLE_TESTING_FLAG='OTHER_SWIFT_FLAGS="-enable-testing \$(inherited)"'
               echo "ENABLE_TESTING_FLAG: $ENABLE_TESTING_FLAG"
           else
               ENABLE_TESTING_FLAG=""

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -345,6 +345,12 @@ jobs:
               RESULTBUNDLE=${{ inputs.resultBundle }}
           fi
 
+          if [ "${{ inputs.buildConfig }}" = "Release" ]; then
+            ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\$(inherited) -enable-testing"
+          else
+            ENABLE_TESTING_FLAG=""
+          fi
+
           set -o pipefail \
           && xcodebuild $XCODECOMMAND \
             -scheme "${{ inputs.scheme }}" \
@@ -354,6 +360,7 @@ jobs:
             -derivedDataPath ".derivedData" \
             -resultBundlePath "$RESULTBUNDLE" \
             CODE_SIGNING_REQUIRED=NO \
+            $ENABLE_TESTING_FLAG
           | xcpretty
     - name: Fastlane
       if: ${{ inputs.fastlanelane != '' }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,7 +346,7 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-              ENABLE_TESTING_FLAG='OTHER_SWIFT_FLAGS="\$(inherited) -enable-testing"'
+              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\"\$(inherited) -enable-testing\""
               echo "ENABLE_TESTING_FLAG: $ENABLE_TESTING_FLAG"
           else
               ENABLE_TESTING_FLAG=""
@@ -361,7 +361,7 @@ jobs:
             -derivedDataPath ".derivedData" \
             -resultBundlePath "$RESULTBUNDLE" \
             CODE_SIGNING_REQUIRED=NO \
-            $ENABLE_TESTING_FLAG \
+            OTHER_SWIFT_FLAGS="\$(inherited) -enable-testing" \
           | xcpretty
     - name: Fastlane
       if: ${{ inputs.fastlanelane != '' }}

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,9 +346,9 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=$(inherited) -enable-testing"
+              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\"\$(inherited) -enable-testing\""
           else
-              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=$(inherited)"
+              ENABLE_TESTING_FLAG=""
           fi
 
           set -o pipefail \

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -346,9 +346,11 @@ jobs:
           fi
 
           if [ "${{ inputs.buildConfig }}" = "Release" ]; then
-            ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\$(inherited) -enable-testing"
+              ENABLE_TESTING_FLAG="OTHER_SWIFT_FLAGS=\$(inherited) -enable-testing"
+              echo "Build config is Release. Setting ENABLE_TESTING_FLAG to '$ENABLE_TESTING_FLAG'"
           else
-            ENABLE_TESTING_FLAG=""
+              ENABLE_TESTING_FLAG=""
+              echo "Build config is not Release. ENABLE_TESTING_FLAG is not set."
           fi
 
           set -o pipefail \


### PR DESCRIPTION
# Add build configuration parameter to enable `Debug` or `Release` builds

## :recycle: Current situation & Problem
As of now, there is no option to adjust the build configuration of the `xcodebuild-or-fastlane.yml` GitHub Action.
This functionality would be very useful, especially for important production builds or repos that rely on low-layer Swift functionality. 


## :gear: Release Notes 
- Add build configuration parameter to `xcodebuild-or-fastlane.yml` to enable `Debug` or `Release` builds


## :books: Documentation
Proper documentation of parameter


## :white_check_mark: Testing
Tested with the `SpeziLLM` action: https://github.com/StanfordSpezi/SpeziLLM/actions/runs/7607351909


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
