### PR TITLE
Add flag to enable -warnings-as-errors Swift complier option

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -100,6 +100,10 @@ on:
         description: "Flag indicating if submodules should be automatically checked out."
         required: false
         type: boolean
+      warningsAsErrors:
+        description: 'Flag indicating if warnings should be treated as errors by the Swift compiler.'
+        required: false
+        type: boolean
     secrets:
       BUILD_CERTIFICATE_BASE64:
         description: 'The Base64 version of the Apple signing certificate to build your iOS application.'
@@ -351,6 +355,12 @@ jobs:
               ENABLE_TESTING_FLAG=""
           fi
 
+          if [ "${{ inputs.warningsAsErrors }}" = true ]; then
+              WARNINGS_AS_ERRORS_FLAG="-warnings-as-errors"
+          else
+              WARNINGS_AS_ERRORS_FLAG=""
+          fi
+
           set -o pipefail \
           && xcodebuild $XCODECOMMAND \
             -scheme "${{ inputs.scheme }}" \
@@ -361,7 +371,7 @@ jobs:
             -resultBundlePath "$RESULTBUNDLE" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
-            OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG" \
+            OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG $WARNINGS_AS_ERRORS_FLAG" \
             -skipPackagePluginValidation \
             -skipMacroValidation \
           | xcpretty


### PR DESCRIPTION
# Add flag to enable -warnings-as-errors Swift complier option 

## :recycle: Current situation & Problem
Currently, there is no option to enable the `-warnings-as-errors` Swift compiler option, which is potentially required by [this PR](https://github.com/StanfordSpezi/Spezi/pull/104).


## :gear: Release Notes 
- Adds `warningsAsErrors` flag to the `build-and-test` workflows to enable the respective `-warnings-as-errors` Swift compiler option. If not provided, the behavior remains the same as before.

## :books: Documentation
- Description for the `warningsAsErrors` parameter has been provided.

## :white_check_mark: Testing
I couldn't test this yet, as I'm not sure what the workflow would be.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
