### PR TITLE
Allow to specify Swift version with xcodebuild

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -42,7 +42,7 @@ on:
         type: string
         default: 'platform=iOS Simulator,name=iPhone 15 Pro'
       setupSimulators:
-        description: 'Flag indicating if all iOS simulators matching the `destination` input shoud be setup (e.g. password autofill functionality should be disabled).'
+        description: 'Flag indicating if all iOS simulators matching the `destination` input should be setup (e.g. password autofill functionality should be disabled).'
         required: false
         type: boolean
         default: false
@@ -377,7 +377,7 @@ jobs:
             -resultBundlePath "$RESULTBUNDLE" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
-            OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG" \
+            OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG --swift-version 6" \
             -skipPackagePluginValidation \
             -skipMacroValidation \
           | xcbeautify

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -51,8 +51,13 @@ on:
         required: false
         type: string
         default: ''
+      swiftVersion:
+        description: 'Specify the Swift language version when using xcodebuild.'
+        required: false
+        type: string
+        default: ''
       test:
-        description: 'A flag indicating if the tests of the Xcode project scheme should run'
+        description: 'A flag indicating if the tests of the Xcode project scheme should run when using xcodebuild.'
         required: false
         type: boolean
         default: true
@@ -366,6 +371,12 @@ jobs:
           else
               ENABLE_TESTING_FLAG=""
           fi
+        
+          if [ -z "${{ inputs.swiftVersion }}"]; then
+              SWIFT_VERSION_FLAG="-swift-version ${{ inputs.swiftVersion }}"
+          else
+              SWIFT_VERSION_FLAG=""
+          fi
 
           set -o pipefail \
           && xcodebuild $XCODECOMMAND \
@@ -377,7 +388,7 @@ jobs:
             -resultBundlePath "$RESULTBUNDLE" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
-            OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG -swift-version 6" \
+            OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG $SWIFT_VERSION_FLAG" \
             -skipPackagePluginValidation \
             -skipMacroValidation \
           | xcbeautify

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -372,7 +372,7 @@ jobs:
               ENABLE_TESTING_FLAG=""
           fi
         
-          if [ -z "${{ inputs.swiftVersion }}"]; then
+          if [ -n "${{ inputs.swiftVersion }}" ]; then
               SWIFT_VERSION_FLAG="-swift-version ${{ inputs.swiftVersion }}"
           else
               SWIFT_VERSION_FLAG=""

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -377,7 +377,7 @@ jobs:
             -resultBundlePath "$RESULTBUNDLE" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
-            OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG --swift-version 6" \
+            OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG -swift-version 6" \
             -skipPackagePluginValidation \
             -skipMacroValidation \
           | xcbeautify


### PR DESCRIPTION
# Allow to specify Swift version with xcodebuild

## :recycle: Current situation & Problem
This PR adds a new input to specify the swift version when running with xcodebuild.


## :gear: Release Notes 
* Add new `swiftVersion` input to the xcodebuild-or-fastlane action.
* Specify more clearly that the `test` input only has an effect when using xcodebuild.


## :books: Documentation
--


## :white_check_mark: Testing
Verified in https://github.com/StanfordSpezi/Spezi/pull/108 (both with not specifying swift version and with specifying a swift version).


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
