### PR TITLE
Remove setupSimulators and cacheDerrivedData

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -86,6 +86,11 @@ on:
         required: false
         type: boolean
         default: false
+      cacheDerivedData:
+        description: 'Cache the derived data folder for a build using xcodebuild [Deprecated].'
+        required: false
+        type: boolean
+        default: false
       setupfirebaseemulator:
         description: 'Setup the Firebase Emulator & automatically use it for the automated fastlane commands.'
         required: false
@@ -174,6 +179,10 @@ jobs:
     - name: Install xcbeautify
       if: ${{ !env.selfhosted && inputs.scheme != '' }}
       run: brew install xcbeautify
+    - name: Cache .derivedData folder (Deprecated)
+      if: ${{ inputs.cacheDerivedData }}
+      run: |
+        echo "::warning::Caching of the .derivedData folder was removed and is deprecated. Plase stop using this option."
     - name: Cache Firebase Emulators
       if: ${{ !env.selfhosted && inputs.setupfirebaseemulator }}
       uses: actions/cache@v4

--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -42,7 +42,7 @@ on:
         type: string
         default: 'platform=iOS Simulator,name=iPhone 15 Pro'
       setupSimulators:
-        description: 'Flag indicating if all iOS simulators matching the `destination` input should be setup (e.g. password autofill functionality should be disabled).'
+        description: 'Flag indicating if all iOS simulators matching the `destination` input should be setup (e.g. password autofill functionality should be disabled) [Deprecated].'
         required: false
         type: boolean
         default: false
@@ -83,11 +83,6 @@ on:
         default: ''
       setupsigning:
         description: 'Setup the keychain to include Apple certificate and provisioning profile'
-        required: false
-        type: boolean
-        default: false
-      cacheDerivedData:
-        description: 'Cache the derived data folder for a build using xcodebuild'
         required: false
         type: boolean
         default: false
@@ -179,14 +174,6 @@ jobs:
     - name: Install xcbeautify
       if: ${{ !env.selfhosted && inputs.scheme != '' }}
       run: brew install xcbeautify
-    - name: Cache .derivedData folder
-      if: ${{ inputs.cacheDerivedData }}
-      uses: actions/cache@v4
-      with:
-        path: .derivedData
-        key: ${{ runner.os }}-${{ runner.arch }}-derivedData-${{ hashFiles('**/Package.swift', '**/*.pbxproj') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-derivedData-
     - name: Cache Firebase Emulators
       if: ${{ !env.selfhosted && inputs.setupfirebaseemulator }}
       uses: actions/cache@v4
@@ -254,85 +241,10 @@ jobs:
       with:
         languages: swift
         db-location: '${{ inputs.path }}/.codeql'
-    - name: Disable Password Autofill in the iOS Simulator
+    - name: Disable Password Autofill in the iOS Simulator (Deprecated)
       if: ${{ inputs.setupSimulators && inputs.destination != '' }}
       run: |
-        # Function to parse the device name from input string
-        parse_device_name() {
-            local input_str=$1
-            local IFS=',' # Set Internal Field Separator to comma for splitting
-            
-            for kv in $input_str; do
-                key="${kv%%=*}"     # Extract key (everything before '=')
-                value="${kv#*=}"    # Extract value (everything after '=')
-                
-                if [ "$key" = "name" ]; then
-                    echo "$value"
-                    return
-                fi
-            done
-        }
-
-        # Extract device name from the input
-        DEVICE_NAME=$(parse_device_name "${{ inputs.destination }}")
-
-        echo "Device name: $DEVICE_NAME"
-        
-        # Retrieve the iOS simulator IDs for the specified device
-        REGEX_PATTERN="$DEVICE_NAME( Simulator)? \(.*\)"
-        SIMULATOR_IDS=$(xctrace list devices | grep -E "$REGEX_PATTERN" | awk '{print $NF}' | tr -d '()')
-
-        # Check if SIMULATOR_IDS is empty
-        if [ -z "$SIMULATOR_IDS" ]; then
-            echo "No simulators found for the specified device."
-            exit 1
-        fi
-
-        # Loop through each Simulator ID
-        for SIMULATOR_ID in $SIMULATOR_IDS; do
-            echo "Processing Simulator ID: $SIMULATOR_ID"
-
-            PLIST1="$HOME/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Containers/Shared/SystemGroup/systemgroup.com.apple.configurationprofiles/Library/ConfigurationProfiles/UserSettings.plist"
-            PLIST2="$HOME/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/UserConfigurationProfiles/EffectiveUserSettings.plist"
-            PLIST3="$HOME/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/UserConfigurationProfiles/PublicInfo/PublicEffectiveUserSettings.plist"
-
-            if [ ! -f "$PLIST1" ] || [ ! -f "$PLIST2" ] || [ ! -f "$PLIST3" ]; then
-                echo "Simulator $SIMULATOR_ID booting ..."
-                xcrun simctl boot "$SIMULATOR_ID"
-            fi
-
-            # Loop for a maximum of 30 seconds
-            for (( i=0; i<30; i++ )); do
-                if [ -f "$PLIST1" ] && [ -f "$PLIST2" ] && [ -f "$PLIST3" ]; then
-                    echo "All files found."
-                    break
-                fi
-                sleep 1
-            done
-
-            # Check if the loop exited because all files were found or because of timeout
-            if [ ! -f "$PLIST1" ] || [ ! -f "$PLIST2" ] || [ ! -f "$PLIST3" ]; then
-                echo "Error: Not all files were found within the 30-second timeout."
-                exit 1
-            fi
-
-            sleep 5
-
-            # Disable AutoFillPasswords
-            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST1
-            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST2
-            plutil -replace restrictedBool.allowPasswordAutoFill.value -bool NO $PLIST3
-            /usr/libexec/PlistBuddy -c "Add :KeyboardContinuousPathEnabled bool false" /Users/githubaction/Library/Developer/CoreSimulator/Devices/$SIMULATOR_ID/data/Library/Preferences/com.apple.keyboard.ContinuousPath.plist
-
-            sleep 1
-
-            # Restart (shutdown if needed and boot) the iOS simulator for the changes to take effect
-            if xcrun simctl shutdown "$SIMULATOR_ID"; then
-                echo "Simulator $SIMULATOR_ID shutdown successfully."
-            else
-                echo "Unable to shutdown simulator $SIMULATOR_ID as it is already shutdown."
-            fi
-        done
+        echo "::warning::Script-based simulator setup to disable Password Autofill was removed and is deprecated. Please stop using this option."
     - name: Run custom command
       if: ${{ inputs.customcommand != '' }}
       run: ${{ inputs.customcommand }}


### PR DESCRIPTION
# Remove setupSimulators and cacheDerrivedData

## :recycle: Current situation & Problem
This PR removes the `setupSimulators` and `cacheDerrivedData` inputs to remove unused or unnecessary functionality.

`cacheDerrivedData` was not used within the Spezi organization, therefore opted to just remove it. `setupSimulators` is still used in the TemplateApplication (PR is up to remove it), SpeziAccount and the Study App. Therefore, opted to print a deprecation notice and remove the script to save some build time.

## :gear: Release Notes 
* Removed `cacheDerrivedData` input
* Removed and deprecated `setupSimulators` script.


## :books: Documentation
Updated the description.


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
