### PR TITLE
Create a text digest of the repository for prompting LLMs

### DIFF
--- a/.github/workflows/create-digest.yml
+++ b/.github/workflows/create-digest.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       source:
-        description: 'Directory to analyze (default: current directory)'
+        description: 'Directory to process (default: current directory)'
         required: false
         default: '.'
         type: string
@@ -73,5 +73,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: repository-digest
-          path: repo-digest.txt
+          path: ${{ inputs.output || 'repo-digest.txt' }}
           retention-days: 30

--- a/.github/workflows/create-digest.yml
+++ b/.github/workflows/create-digest.yml
@@ -1,0 +1,38 @@
+#
+# This source file is part of the Stanford Spezi open-source project
+#
+# SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Generate Repository Digest
+
+on:
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+          
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          
+      - name: Install gitingest
+        run: pip install gitingest
+        
+      - name: Generate digest
+        run: |
+          gitingest . > repo-digest.txt
+          
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: repository-digest
+          path: repo-digest.txt
+          retention-days: 30

--- a/.github/workflows/create-digest.yml
+++ b/.github/workflows/create-digest.yml
@@ -10,26 +10,65 @@ name: Generate Repository Digest
 
 on:
   workflow_dispatch:
-
+    inputs:
+      source:
+        description: 'Directory to analyze (default: current directory)'
+        required: false
+        default: '.'
+        type: string
+      output:
+        description: 'Output file path'
+        required: false
+        default: 'repo-digest.txt'
+      max_size:
+        description: 'Maximum file size to process (in bytes)'
+        required: false
+        type: number
+      exclude_patterns:
+        description: 'Space-separated patterns to exclude'
+        required: false
+        type: string
+      include_patterns:
+        description: 'Space-separated patterns to include'
+        required: false
+        type: string
 jobs:
-  analyze:
+  generate:
     runs-on: ubuntu-latest
-    
     steps:
       - uses: actions/checkout@v4
-          
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-          
       - name: Install gitingest
         run: pip install gitingest
-        
       - name: Generate digest
         run: |
-          gitingest . > repo-digest.txt
+          COMMAND="gitingest"
+        
+          if [ -n "${{ inputs.output }}" ]; then
+            COMMAND="$COMMAND -o ${{ inputs.output }}"
+          fi
+        
+          if [ -n "${{ inputs.max_size }}" ]; then
+            COMMAND="$COMMAND -s ${{ inputs.max_size }}"
+          fi
+        
+          if [ -n "${{ inputs.exclude_patterns }}" ]; then
+            for pattern in ${{ inputs.exclude_patterns }}; do
+              COMMAND="$COMMAND --exclude-pattern '$pattern'"
+            done
+          fi
           
+          if [ -n "${{ inputs.include_patterns }}" ]; then
+            for pattern in ${{ inputs.include_patterns }}; do
+              COMMAND="$COMMAND --include-pattern '$pattern'"
+            done
+          fi
+        
+          COMMAND="$COMMAND ${{ inputs.source || '.' }}"
+          eval $COMMAND
       - name: Upload digest artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
# Create a text digest of the repository for prompting LLMs

This PR creates an action that generates a "prompt-friendly" text digest of a given repository to be used with an LLM (e.g. a coding assistant) and uploads it as an artifact.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
