### PR TITLE
bring xcodebuild-or-fastlane in sync with the StanfordBDHG org's version

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -236,6 +236,7 @@ jobs:
             swift --version
             echo "env.selfhosted: ${{ env.selfhosted }}"
             echo "environment: ${{ inputs.environment }}"
+            xcrun simctl list
       - name: Install xcbeautify
         if: ${{ !env.selfhosted && inputs.scheme != '' }}
         run: brew install xcbeautify
@@ -322,6 +323,10 @@ jobs:
         if: ${{ inputs.setupSimulators && inputs.destination != '' }}
         run: |
           echo "::warning::Script-based simulator setup to disable Password Autofill was removed and is deprecated. Please stop using this option."
+      - name: Check available Simulators
+        if: ${{ inputs.scheme != '' }}
+        run: |
+          xcrun xcodebuild -scheme ${{ inputs.scheme }} -showdestinations
       - name: Run custom command
         if: ${{ inputs.customcommand != '' }}
         run: ${{ inputs.customcommand }}


### PR DESCRIPTION
# bring xcodebuild-or-fastlane in sync with BDHG/.github

## :recycle: Current situation & Problem
This PR incorporates recent changes to the StanfordBDHG org's `xcodebuild-or-fastlane` workflow into the one in the StanfordSpezi org.

## :gear: Release Notes
- add simulator availability checking step

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
