### PR TITLE
add `testplan` option

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -77,6 +77,12 @@ on:
         required: false
         type: boolean
         default: true
+      testplan:
+        description: |
+          The Test Plan that should be run.
+        required: false
+        type: string
+        default: ''
       fastlanelane:
         description: |
           The lane of the fastlane command.
@@ -372,11 +378,18 @@ jobs:
                 SWIFT_VERSION_FLAG=""
             fi
 
+            if [ -n "${{ inputs.testplan }}" ]; then
+                TESTPLAN=(-testPlan "${{ inputs.testplan }}")
+            else
+                TESTPLAN=()
+            fi
+
             set -o pipefail \
             && xcodebuild $XCODECOMMAND \
               -scheme "${{ inputs.scheme }}" \
               -configuration "${{ inputs.buildConfig }}" \
               -destination "${{ inputs.destination }}" \
+              "${TESTPLAN[@]}" \
               $CODECOVERAGEFLAG \
               -derivedDataPath ".derivedData" \
               -resultBundlePath "$RESULTBUNDLE" \


### PR DESCRIPTION
# add `testplan` option

## :recycle: Current situation & Problem
this PR adds the `testplan` option recently added to StanforfBDHG/.github


## :gear: Release Notes
- added a new optional testplan input to the xcodebuild-or-fastlane action


## :books: Documentation
the new input is documented


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
