### PR TITLE
Reusable GitHub action for swift api break diagnose

### DIFF
--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -1,0 +1,17 @@
+name: Diagnose Breaking Changes
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The name of the branch to compare against'
+        required: true
+        type: string
+
+jobs:
+  diagnose:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run diagnose-api-breaking-changes
+        run: swift package diagnose-api-breaking-changes ${{ inputs['branch'] }}

--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -1,3 +1,11 @@
+#
+# This source file is part of the Stanford Spezi open-source project
+#
+# SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
 name: Diagnose Breaking Changes
 
 on:

--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -5,8 +5,9 @@ on:
     inputs:
       branch:
         description: 'The name of the branch to compare against'
-        required: true
+        required: false
         type: string
+        default: 'main'
       runsonlabels:
         description: JSON-based collection of labels indicating which type of github runner should be chosen.
         required: false
@@ -18,5 +19,7 @@ jobs:
     runs-on: ${{ fromJson(inputs.runsonlabels) }}
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch base branch
+        run: git fetch origin ${{ inputs['branch'] }}:${{ inputs['branch'] }}
       - name: Run diagnose-api-breaking-changes
         run: swift package diagnose-api-breaking-changes ${{ inputs['branch'] }}

--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -7,10 +7,15 @@ on:
         description: 'The name of the branch to compare against'
         required: true
         type: string
+      runsonlabels:
+        description: JSON-based collection of labels indicating which type of github runner should be chosen.
+        required: false
+        type: string
+        default: '["macos-latest"]'
 
 jobs:
   diagnose:
-    runs-on: macos-latest
+    runs-on: ${{ fromJson(inputs.runsonlabels) }}
     steps:
       - uses: actions/checkout@v4
       - name: Run diagnose-api-breaking-changes


### PR DESCRIPTION
# Reusable GitHub action for swift api break diagnose


## :gear: Release Notes
* New reusable GitHub action.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
