### PR TITLE
update default `destination` to iPhone 17 Pro

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -47,10 +47,10 @@ on:
       destination:
         description: |
           The destination parameter that should be passed to xcodebuild.
-          Defaults to the iOS simulator using an iPhone 16 Pro.
+          Defaults to the iOS simulator using an iPhone 17 Pro.
         required: false
         type: string
-        default: 'platform=iOS Simulator,name=iPhone 16 Pro'
+        default: 'platform=iOS Simulator,name=iPhone 17 Pro'
       setupSimulators:
         description: |
           Flag indicating if all iOS simulators matching the `destination` input shoud be setup.


### PR DESCRIPTION
# update default `destination` to iPhone 17 Pro

## :recycle: Current situation & Problem
required update now that the CI is using Xcode 26


## :gear: Release Notes
- the `build-and-test` workflow's `destination` input now defaults to an iPhone 17 Pro


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
