### PR TITLE
sync with BDHG/.github; add `spm-disable-prebuilts`

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -22,7 +22,7 @@ on:
           JSON-based collection of labels indicating which type of github runner should be chosen.
         required: false
         type: string
-        default: '["macos-15"]'
+        default: '["macos-26"]'
       xcodeversion:
         description: |
           The Xcode version used for the build.
@@ -83,6 +83,11 @@ on:
         required: false
         type: string
         default: ''
+      spm-disable-prebuilts:
+        description: |
+          Disables package prebuilts when resolving SPM dependencies
+        type: boolean
+        default: false
       fastlanelane:
         description: |
           The lane of the fastlane command.
@@ -348,6 +353,7 @@ jobs:
               -scheme ${{ inputs.scheme }} \
               -resolvePackageDependencies \
               -derivedDataPath ".derivedData" \
+              ${{ inputs.spm-disable-prebuilts && '-IDEPackageEnablePrebuilts=NO' || '' }} \
             | xcbeautify \
             || true
       - name: Build and test (xcodebuild)
@@ -398,6 +404,7 @@ jobs:
               OTHER_SWIFT_FLAGS="\$(inherited) $ENABLE_TESTING_FLAG $SWIFT_VERSION_FLAG" \
               -skipPackagePluginValidation \
               -skipMacroValidation \
+              ${{ inputs.spm-disable-prebuilts && '-IDEPackageEnablePrebuilts=NO' || '' }} \
             | xcbeautify
       - name: Fastlane
         if: ${{ inputs.fastlanelane != '' }}


### PR DESCRIPTION
# sync with BDHG/.github; add `spm-disable-prebuilts`

## :recycle: Current situation & Problem
see https://github.com/StanfordBDHG/.github/pull/140 for more details

## :gear: Release Notes
- sync with the workflow in the BDHG repo
    - updated the default runner to macos-26
    - added a `spm-disable-prebuilts` option to the xcodebuild-or-fastlane workflow


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
